### PR TITLE
[FEATURE] Importer le fichier .parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+weather.parquet

--- a/manage-data.ipynb
+++ b/manage-data.ipynb
@@ -10,12 +10,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import os"
+    "import os\n",
+    "from fastparquet import ParquetFile"
    ]
   },
   {
@@ -28,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,12 +42,12 @@
    "metadata": {},
    "source": [
     "## Description\n",
-    "Test des csv"
+    "Importation des fichiers"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,12 +61,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Filtrage du circuit"
+    "## Description de la cellule\n",
+    "Filtrage des données"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,12 +87,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Description de la cellule\n",
+    "Importation du fichier parquet"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Affichage des csv"
+    "dp = ParquetFile('weather.parquet')\n",
+    "weather = dp.to_pandas()"
    ]
   }
  ],
@@ -99,18 +110,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ cffi==1.17.1
 charset-normalizer==3.3.2
 comm==0.2.2
 contourpy==1.3.0
+cramjam==2.8.3
 cycler==0.12.1
 Cython==3.0.11
 debugpy==1.8.5
@@ -21,8 +22,10 @@ decorator==5.1.1
 defusedxml==0.7.1
 executing==2.1.0
 fastjsonschema==2.20.0
+fastparquet==2024.5.0
 fonttools==4.53.1
 fqdn==1.5.1
+fsspec==2024.9.0
 h11==0.14.0
 httpcore==1.0.5
 httpx==0.27.2


### PR DESCRIPTION
## Pourquoi?
Ajouter une cellule dans le fichier notebook pour importer le fichier parquet avec fastParquet.

## Remarque
Le fichier étant trop volumineux, il faut se le procurer via l'intranet pédagogique.